### PR TITLE
Nsdc

### DIFF
--- a/java/elastic-search/src/main/java/dev/sunbirdrc/elastic/ElasticServiceImpl.java
+++ b/java/elastic-search/src/main/java/dev/sunbirdrc/elastic/ElasticServiceImpl.java
@@ -100,8 +100,11 @@ public class ElasticServiceImpl implements IElasticService {
         credentialsProvider.setCredentials(AuthScope.ANY,
                 new UsernamePasswordCredentials(userName, password));
         if (!esClient.containsKey(indexName)) {
+            // KeyValue key is port and value is scheme type.
             Map<String, KeyValue<Integer, String>> hostPort = new HashMap<>();
             for (String info : connectionInfo.split(",")) {
+                // use URL to get sceme/protocol if defined else fall back to earlier mechanism
+                // of configuring host/port
                 try {
                     URL url = new URL(info);
                     hostPort.put(url.getHost(), new DefaultKeyValue<>(url.getPort(), url.getProtocol()));
@@ -404,6 +407,10 @@ public class ElasticServiceImpl implements IElasticService {
         this.password = password;
     }
 
+    /**
+     * set default scheme used in setting protocol for RestHighEndClient
+     * @param scheme
+     */
     public void setScheme(String scheme) {
         this.defaultScheme = scheme;
     }

--- a/java/registry/src/main/java/dev/sunbirdrc/registry/config/GenericConfiguration.java
+++ b/java/registry/src/main/java/dev/sunbirdrc/registry/config/GenericConfiguration.java
@@ -132,6 +132,8 @@ public class GenericConfiguration implements WebMvcConfigurer {
 	private String username;
 	@Value("${elastic.search.elastic_password}")
 	private String password;
+	@Value("${elastic.search.scheme}")
+	private String scheme;
 	@Value("${notification.service.connection_url}")
 	private String notificationServiceConnInfo;
 	@Value("${search.providerName}")
@@ -421,6 +423,7 @@ public class GenericConfiguration implements WebMvcConfigurer {
 			elasticService.setAuthEnabled(Boolean.parseBoolean(authEnabled));
 			elasticService.setUserName(username);
 			elasticService.setPassword(password);
+			elasticService.setScheme(scheme);
 			elasticService.init(definitionsManager.getAllKnownDefinitions(), definitionsManager.getExcludingFields());
 		}
 		return elasticService;

--- a/java/registry/src/main/resources/application.yml
+++ b/java/registry/src/main/resources/application.yml
@@ -287,6 +287,7 @@ elastic:
     auth_enabled: ${elastic_search_auth_enabled:false}
     elastic_username: ${elastic_search_username:elastic}
     elastic_password: ${elastic_search_password:XXXXXX}
+    scheme: ${elastic_search_scheme:http}
 filestorage:
   url: ${filestorage_connection_url:http://localhost:9000}
   accesskey: ${filestorage_access_key:XXXXX}


### PR DESCRIPTION
For NSDC ES is hosted on secured http protocol.

- Added support to extract scheme/protocol if complete url with scheme is set  via `elastic.search.connection_url` or `elastic_search_connection_url`
- Added support to specify default scheme env variable `elastic_search_scheme`, or `elastic.search.scheme`